### PR TITLE
Fix empty locales and don't fail on symlinked desktop entries

### DIFF
--- a/src/app_chooser_page.js
+++ b/src/app_chooser_page.js
@@ -66,7 +66,7 @@ export const AppChooserPage = GObject.registerClass({
 		let total_rows = 0;
 		let dir_with_enumerator = dirs_with_enumerators[index];
 		const iteration = () => {
-			const path = dir_with_enumerator.path;
+			const folder_path = dir_with_enumerator.path;
 			const enumerator = dir_with_enumerator.enumerator;
 			const info = enumerator.next_file(null);
 			if (info === null) {
@@ -85,13 +85,17 @@ export const AppChooserPage = GObject.registerClass({
 				// Skip this iteration if the file is not a .desktop file
 				return true;
 			}
-			const entry = new AutostartEntry(`${path}/${info.get_name()}`);
+			const file_path = `${folder_path}/${info.get_name()}`;
+			let entry;
+			try {
+				entry = new AutostartEntry(file_path);
+			} catch (error) {
+				print("Ignition error: AppChooserPage: Error creating AutostartEntry: " + error);
+				return true;
+			}
 			const kf = new GLib.KeyFile();
 			try {
-				kf.load_from_file(
-					`${path}/${info.get_name()}`,
-					GLib.KeyFileFlags.KEEP_TRANSLATIONS,
-				);
+				kf.load_from_file(file_path, GLib.KeyFileFlags.KEEP_TRANSLATIONS);
 			} catch (error) { return true; }
 			const hidden = (
 				KeyFileUtils.get_boolean_safe(kf, "Desktop Entry", "Hidden", false)

--- a/src/autostart_entry.js
+++ b/src/autostart_entry.js
@@ -29,11 +29,17 @@ export class AutostartEntry {
 	}
 
 	set name(value) {
-		this.keyfile.set_locale_string("Desktop Entry", "Name", this.locale, value);
+		this.keyfile.set_string("Desktop Entry", "Name", value);
+		if (this.locale !== null) {
+			this.keyfile.set_locale_string("Desktop Entry", "Name", this.locale, value);
+		}
 	}
 
 	set comment(value) {
-		this.keyfile.set_locale_string("Desktop Entry", "Comment", this.locale, value);
+		this.keyfile.set_string("Desktop Entry", "Comment", value);
+		if (this.locale !== null) {
+			this.keyfile.set_locale_string("Desktop Entry", "Comment", this.locale, value);
+		}
 	}
 
 	set exec(value) {
@@ -82,7 +88,7 @@ export class AutostartEntry {
 
 	path;
 	keyfile = new GLib.KeyFile({});
-	locale = "en_US";
+	locale = null;
 	signals = {
 		file_saved: new Signal(),
 		file_save_failed: new Signal(),
@@ -103,7 +109,7 @@ export class AutostartEntry {
 				throw new Error("Desktop Entry is not of type Application");
 			}
 			try {
-				this.locale = this.keyfile.get_locale_for_key("Desktop Entry", "Name", null) || "en_US";
+				this.locale = this.keyfile.get_locale_for_key("Desktop Entry", "Name", null);
 			} catch (error) {
 				// Not having a name set is fine
 			}


### PR DESCRIPTION
This PR fixes 2 problems I encountered when running Ignition on an Ubuntu 24.04 Arm Linux VM:

* Don't stall the app when reading symlinked desktop entries.
    * When I first opened the app, a symlink in my system `/usr/share/applications/` folder caused Ignition to not start at all. The not-perfect fix is to throw this inside of a `try`/`catch` block. A better fix later would be to fix following symlinks, however, it is still a good idea to have this `try`/`catch` block in case other errors occur.
* Fix empty locales by always saving a non-locale version.
    * The flatpak environment did not have a locale set on my system for some reason. This caused the getter to fail, though the setter was still using `en_US` as a fallback. The solution here is to make it work for these situations by always saving a non-locale version of the string, so always save `Name=` in addition to `Name[en_US]`.
    * Additionally, the fallback locale has been changed to null instead of `en_US`. The setters now check for this, and skip setting the locale version if the locale is null. I think these two setters are the only place where this specific locale property is checked, so this should be fine.