### PR TITLE
Add Drag & Drop Reordering and Sort Functionality

### DIFF
--- a/data/style.css
+++ b/data/style.css
@@ -1,0 +1,5 @@
+/* Drag and drop styles */
+.drag-active {
+	opacity: 0.4;
+}
+

--- a/src/gtk/entry_group.ts
+++ b/src/gtk/entry_group.ts
@@ -4,6 +4,7 @@ import { AutostartEntry } from "src/utils/autostart_entry.js";
 import { Signal } from "../utils/signal.js";
 
 import GObject from "gi://GObject?version=2.0";
+import Gdk from "gi://Gdk?version=4.0";
 import Gtk from "gi://Gtk?version=4.0";
 import Adw from "gi://Adw?version=1";
 
@@ -30,20 +31,80 @@ export class EntryGroup extends Gtk.Box {
 	readonly signals = {
 		row_clicked: new Signal<[EntryRow]>(),
 		finished_loading: new Signal<[EntryGroup]>(),
+		reordered: new Signal<[EntryRow, number]>(),
 	} as const;
+
+	#dragged_row: EntryRow | null = null;
 
 	constructor(params?: Adw.PreferencesGroup.ConstructorProps) {
 		super(params);
+	}
 
-		this._list_box.set_sort_func((row1, row2) => {
-			let entry_row1 = row1 as EntryRow;
-			let entry_row2 = row2 as EntryRow;
-
-			return (entry_row1.sort_priority === entry_row2.sort_priority
-				? +(entry_row1.title.toLowerCase() > entry_row2.title.toLowerCase())
-				: +(entry_row1.sort_priority < entry_row2.sort_priority)
-			);
+	#setup_drag_and_drop(row: EntryRow): void {
+		// Set up the row as a drag source
+		const drag_source = new Gtk.DragSource({
+			actions: Gdk.DragAction.MOVE,
 		});
+
+		drag_source.connect("prepare", (_source, _x, _y) => {
+			this.#dragged_row = row;
+			return Gdk.ContentProvider.new_for_value(row);
+		});
+
+		drag_source.connect("drag-begin", (_source, drag) => {
+			const drag_widget = new Gtk.ListBox();
+			drag_widget.add_css_class("boxed-list");
+			const drag_row = new EntryRow(row.entry, true);
+			drag_widget.append(drag_row);
+			drag_widget.drag_highlight_row(drag_row);
+
+			const icon = Gtk.DragIcon.get_for_drag(drag) as Gtk.DragIcon;
+			icon.set_child(drag_widget);
+
+			row.add_css_class("drag-active");
+		});
+
+		drag_source.connect("drag-end", () => {
+			row.remove_css_class("drag-active");
+			this.#dragged_row = null;
+		});
+
+		row.add_controller(drag_source);
+
+		// Set up the row as a drop target
+		const drop_target = new Gtk.DropTarget({
+			actions: Gdk.DragAction.MOVE,
+		});
+		drop_target.set_gtypes([EntryRow.$gtype]);
+
+		drop_target.connect("drop", (_target, value, _x, y) => {
+			const source_row = value as unknown as EntryRow;
+			if (source_row === row) {
+				return false;
+			}
+
+			const row_height = row.get_height();
+			const drop_after = y > row_height / 2;
+
+			// Get the current position of the target row
+			const target_index = row.get_index();
+			const source_index = source_row.get_index();
+
+			// Remove the source row and insert it at the new position
+			this._list_box.remove(source_row);
+
+			let new_index = drop_after ? target_index : target_index;
+			if (source_index < target_index) {
+				new_index = drop_after ? target_index : target_index - 1;
+			}
+
+			this._list_box.insert(source_row, new_index);
+
+			this.signals.reordered.emit(source_row, new_index);
+			return true;
+		});
+
+		row.add_controller(drop_target);
 	}
 
 	search_changed(value: string): void {
@@ -77,6 +138,7 @@ export class EntryGroup extends Gtk.Box {
 			}
 			const row = new EntryRow(entry, true);
 			row.connect("activated", () => this.signals.row_clicked.emit(row));
+			this.#setup_drag_and_drop(row);
 			this._list_box.append(row);
 			return Async.CONTINUE;
 		}

--- a/src/io.github.flattool.Ignition.data.gresource.xml
+++ b/src/io.github.flattool.Ignition.data.gresource.xml
@@ -2,6 +2,7 @@
 <gresources>
   <gresource prefix="/io/github/flattool/Ignition">
     <file preprocess="xml-stripblanks" alias="appdata">../data/io.github.flattool.Ignition.metainfo.xml</file>
+    <file alias="style.css">../data/style.css</file>
     <file preprocess="xml-stripblanks">first_run_page/first-run-page.ui</file>
     <file preprocess="xml-stripblanks">gtk/entry-group.ui</file>
     <file preprocess="xml-stripblanks">gtk/entry-row.ui</file>

--- a/src/main.ts
+++ b/src/main.ts
@@ -120,8 +120,18 @@ class IgnitionApplication extends Adw.Application {
 	vfunc_activate() {
 		let { active_window } = this;
 
-		if (!active_window)
+		if (!active_window) {
+			// Load the CSS stylesheet
+			const css_provider = new Gtk.CssProvider();
+			css_provider.load_from_resource("/io/github/flattool/Ignition/style.css");
+			Gtk.StyleContext.add_provider_for_display(
+				Gdk.Display.get_default()!,
+				css_provider,
+				Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
+			);
+
 			active_window = new IgnitionWindow({ application: this });
+		}
 
 		active_window.present();
 	}


### PR DESCRIPTION
This pull request introduces drag-and-drop reordering for entry rows in the `EntryGroup` UI, along with the necessary styling and resource management to support this feature. The main changes include implementing drag-and-drop logic, emitting a new signal when rows are reordered, and loading a custom CSS file for drag-and-drop visual feedback.

**Drag-and-drop reordering and UI updates:**

* Added drag-and-drop functionality to `EntryGroup`, allowing users to reorder `EntryRow` items interactively. This includes logic for drag sources, drop targets, and updating the row order in the UI. A new `reordered` signal is emitted when a row is moved. (`src/gtk/entry_group.ts`) [[1]](diffhunk://#diff-4e8a4c10bd4d5609d63549d46683d56985042f5d5919d702952aa16d6fd320d2R34-R107) [[2]](diffhunk://#diff-4e8a4c10bd4d5609d63549d46683d56985042f5d5919d702952aa16d6fd320d2R141)
* Introduced a new private field `#dragged_row` to track the row being dragged. (`src/gtk/entry_group.ts`)

**Styling and resource management:**

* Added a new CSS rule `.drag-active` to visually indicate a row being dragged, and ensured the stylesheet is loaded at application startup. (`data/style.css`, `src/main.ts`) [[1]](diffhunk://#diff-64b04ed67ae0ddec074a7f09c5ea46fca5ab8ae4f8e1343126f06ebcffd92a80R1-R5) [[2]](diffhunk://#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3dL123-R134)
* Updated the resource manifest to include the new `style.css` file. (`src/io.github.flattool.Ignition.data.gresource.xml`)

**Dependency updates:**

* Imported `Gdk` in `entry_group.ts` to support drag-and-drop actions. (`src/gtk/entry_group.ts`)